### PR TITLE
feat: support GitHub Enterprise Server

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -103,15 +103,11 @@ func (r *Runner) action(c *cli.Context) error {
 		return err
 	}
 	setLogLevel(params.LogLevel)
-	params.GitHubToken = getGitHubToken(params.GitHubToken)
-
-	ghParams := github.ParamsNew{
-		Token:      params.GitHubToken,
+	ghClient, err := github.New(c.Context, github.ParamsNew{
+		Token:      getGitHubToken(params.GitHubToken),
 		BaseURL:    params.GitHubAPIURL,
 		GraphQLURL: params.GitHubGraphQLURL,
-	}
-
-	ghClient, err := github.New(c.Context, ghParams)
+	})
 	if err != nil {
 		return fmt.Errorf("create a GitHub client: %w", err)
 	}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -44,6 +44,16 @@ func (r *Runner) runCommand() *cli.Command {
 				Usage: "GitHub Access Token [$GITHUB_TOKEN, $GITHUB_ACCESS_TOKEN]",
 			},
 			&cli.StringFlag{
+				Name:    "github-api-url",
+				Usage:   "GitHub API Base URL",
+				EnvVars: []string{"GITHUB_API_URL"},
+			},
+			&cli.StringFlag{
+				Name:    "github-graphql-url",
+				Usage:   "GitHub GraphQL API URL",
+				EnvVars: []string{"GITHUB_GRAPHQL_URL"},
+			},
+			&cli.StringFlag{
 				Name:  "prefix",
 				Usage: "The prefix of environment variable name",
 				Value: "CI_INFO_",
@@ -81,6 +91,8 @@ func (r *Runner) setCLIArg(c *cli.Context, params domain.Params) domain.Params {
 	if prNum := c.Int("pr"); prNum > 0 {
 		params.PRNum = prNum
 	}
+	params.GitHubAPIURL = c.String("github-api-url")
+	params.GitHubGraphQLURL = c.String("github-graphql-url")
 	return params
 }
 
@@ -93,9 +105,16 @@ func (r *Runner) action(c *cli.Context) error {
 	setLogLevel(params.LogLevel)
 	params.GitHubToken = getGitHubToken(params.GitHubToken)
 
-	ghClient := github.New(c.Context, github.ParamsNew{
-		Token: params.GitHubToken,
-	})
+	ghParams := github.ParamsNew{
+		Token:      params.GitHubToken,
+		BaseURL:    params.GitHubAPIURL,
+		GraphQLURL: params.GitHubGraphQLURL,
+	}
+
+	ghClient, err := github.New(c.Context, ghParams)
+	if err != nil {
+		return fmt.Errorf("create a GitHub client: %w", err)
+	}
 
 	fs := afero.NewOsFs()
 

--- a/pkg/domain/params.go
+++ b/pkg/domain/params.go
@@ -1,12 +1,14 @@
 package domain
 
 type Params struct {
-	Owner       string
-	Repo        string
-	SHA         string
-	Dir         string
-	PRNum       int
-	GitHubToken string
-	LogLevel    string
-	Prefix      string
+	Owner            string
+	Repo             string
+	SHA              string
+	Dir              string
+	PRNum            int
+	GitHubToken      string
+	GitHubAPIURL     string
+	GitHubGraphQLURL string
+	LogLevel         string
+	Prefix           string
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -23,8 +23,8 @@ type Client struct {
 }
 
 type ParamsNew struct {
-	Token string
-	BaseURL string
+	Token      string
+	BaseURL    string
 	GraphQLURL string
 }
 
@@ -33,7 +33,7 @@ func New(ctx context.Context, params ParamsNew) (Client, error) {
 	if params.BaseURL != "" {
 		gh, err := gh.WithEnterpriseURLs(params.BaseURL, params.BaseURL)
 		if err != nil {
-return Client{}, err
+			return Client{}, err
 		}
 		return Client{
 			Client: gh,
@@ -45,7 +45,7 @@ return Client{}, err
 }
 
 func newGitHub(ctx context.Context, token string) *github.Client {
-			return github.NewClient(newHTTP(ctx, token))
+	return github.NewClient(newHTTP(ctx, token))
 }
 
 func newHTTP(ctx context.Context, token string) *http.Client {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -24,19 +24,37 @@ type Client struct {
 
 type ParamsNew struct {
 	Token string
+	BaseURL string
+	GraphQLURL string
 }
 
-func New(ctx context.Context, params ParamsNew) Client {
-	if params.Token == "" {
-		return Client{
-			Client: github.NewClient(http.DefaultClient),
+func New(ctx context.Context, params ParamsNew) (Client, error) {
+	gh := newGitHub(ctx, params.Token)
+	if params.BaseURL != "" {
+		gh, err := gh.WithEnterpriseURLs(params.BaseURL, params.BaseURL)
+		if err != nil {
+return Client{}, err
 		}
+		return Client{
+			Client: gh,
+		}, nil
 	}
 	return Client{
-		Client: github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: params.Token},
-		))),
+		Client: gh,
+	}, nil
+}
+
+func newGitHub(ctx context.Context, token string) *github.Client {
+			return github.NewClient(newHTTP(ctx, token))
+}
+
+func newHTTP(ctx context.Context, token string) *http.Client {
+	if token == "" {
+		return http.DefaultClient
 	}
+	return oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	))
 }
 
 type ParamsGetPR struct {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/google/go-github/v63/github"
@@ -33,7 +34,7 @@ func New(ctx context.Context, params ParamsNew) (Client, error) {
 	if params.BaseURL != "" {
 		gh, err := gh.WithEnterpriseURLs(params.BaseURL, params.BaseURL)
 		if err != nil {
-			return Client{}, err
+			return Client{}, fmt.Errorf("configure GitHub API Baase URL: %w", err)
 		}
 		return Client{
 			Client: gh,


### PR DESCRIPTION
Add command line options to set GitHub API URL and GitHub GraphQL API URL. ci-info gets their values from environment variables GITHUB_API_URL and GITHUB_GRAPHQL_URL.