### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,9 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,14 +1,21 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write
 
   integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -19,7 +19,9 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,6 +30,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: go run ./cmd/ci-info run
         env:
           GITHUB_TOKEN: ${{github.token}}


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://github.com/suzuki-shunsuke/ghalint) into the CI workflows.
This applies the same pattern as ghalint's [#1361](https://github.com/suzuki-shunsuke/ghalint/pull/1361) / [#1362](https://github.com/suzuki-shunsuke/ghalint/pull/1362).

It passes the `TAKUMI_GUARD_BOT_ID` secret and the `id-token: write` permission to the reusable workflows (`go-test-full-workflow`, `go-release-workflow`) to enable validation by Takumi Guard. The reusable workflows are also updated to versions that support Takumi Guard. In addition, Takumi Guard is set up in the `integration-test` job.

## Changes

### `.github/workflows/release.yaml`
- Update `go-release-workflow` from `v8.0.0` to `v8.1.0`
- Pass `secrets.TAKUMI_GUARD_BOT_ID`

### `.github/workflows/test.yaml`
- Add `secrets.TAKUMI_GUARD_BOT_ID` to the `test` job
- Add the `id-token: write` permission

### `.github/workflows/workflow_call_test.yaml`
- Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`)
- Update `go-test-full-workflow` from `v5.0.2` to `v6.0.0`
- Pass `secrets.TAKUMI_GUARD_BOT_ID` to the `test` job and add the `id-token: write` permission
- Add a `flatt-security/setup-takumi-guard-golang@v1` step to the `integration-test` job and add the `contents: read` / `id-token: write` permissions

## Note

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)