### PR TITLE
fix: adapt the test to go-github v90 value fields

### DIFF
--- a/pkg/write/write_internal_test.go
+++ b/pkg/write/write_internal_test.go
@@ -13,10 +13,10 @@ func Test_labelsTxt(t *testing.T) {
 	}
 	s := labelsTxt([]*github.Label{
 		{
-			Name: new("bug"),
+			Name: "bug",
 		},
 		{
-			Name: new("foo"),
+			Name: "foo",
 		},
 	})
 	exp := `bug


### PR DESCRIPTION
Fixes the CI failure on #1694 so that go-github v90 can be merged.

`github.Label.Name` became a `string` in go-github v90, so the `new(...)` wrappers in the
`labelsTxt` test no longer compile:

```
pkg/write/write_internal_test.go:16:10: cannot use new("bug") (value of type *string) as string value in struct literal
pkg/write/write_internal_test.go:19:10: cannot use new("foo") (value of type *string) as string value in struct literal
```

Only the test is affected. `labelsTxt` itself reads the field through `label.GetName()`, which
go-github still generates for value fields, so no production code changes.

Verified locally: `go build ./...`, `go vet ./...` and `go test ./...` all pass.

Base is the Renovate branch, so merging this puts the fix on #1694 and leaves that PR to merge
into main as usual.
